### PR TITLE
Fix chrome dev tools crashing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+/*! @import */
 @import 'tailwindcss/base.css';
 @import 'tailwindcss/components.css';
 @import 'tailwindcss/utilities.css';


### PR DESCRIPTION
I am so sorry that this is the fix 😅  Basically vite uses the constructable stylesheets API which is not good for large files. This tricks it into using a simpler approach and should fix your issue.